### PR TITLE
Alter naming in ZD ASG switching to current Amazonia naming scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.1] - 07/11/2016
+- Change naming scheme for ZD ASG switch
+
 ## [1.0.0] - 17/08/2016
 - Adding changelog.md file


### PR DESCRIPTION
Remove logical stack name, change ordering of object/unit/stack names